### PR TITLE
Change java.exe default location...

### DIFF
--- a/Build.py
+++ b/Build.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup
 from requests import get
 from undetected_chromedriver import Chrome, ChromeOptions
 
-ZULU_JAVA_EXE = r"C:\Program Files\Java\jdk-zulu17\bin\java.exe"
+ZULU_JAVA_EXE = r"C:\Program Files\Zulu\zulu-17\bin\java.exe"
 
 
 def delete_old_items():


### PR DESCRIPTION
Change java.exe default location to reflect the default install directory of Azul Zulu JDK 17, according to their documentation, and verified in my own system.

This matches the requiriments provided in the How To Use, and I think would make it easier for users that don't want to manually edit the file path back to the original Default one.

Cheers! :D

[Zulu docs mentioned.](https://docs.azul.com/core/zulu-openjdk/install/windows#:~:text=The%20default%20installation%20folder%20is,package%20(JDK%20or%20JRE).)